### PR TITLE
Revert replays actions from reverted transaction. This test exposes it.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,12 @@ function optimist(fn) {
     if (Object.keys(optimist).length) {
       let newOptimist = {};
       Object.keys(optimist).forEach(function (key) {
-        newOptimist[key] = {state: optimist[key].state, actions: optimist[key].actions.concat([action])};
+	if (action.optimist && action.optimist.id == key) {
+          newOptimist[key] = optimist[key];
+	}
+	else {
+          newOptimist[key] = {state: optimist[key].state, actions: optimist[key].actions.concat([action])};
+	}
       });
       optimist = newOptimist;
     }

--- a/test/index.js
+++ b/test/index.js
@@ -219,6 +219,9 @@ test('real world example', () => {
         optimist: transactionID ? {type: optimist.BEGIN, id: transactionID} : undefined
       };
     },
+    begin(transactionID) {
+      return {type: 'BEGIN', optimist: {type: optimist.BEGIN, id: transactionID}};
+    },
     commit(transactionID) {
       return {type: 'COMMIT', optimist: {type: optimist.COMMIT, id: transactionID}};
     },
@@ -229,10 +232,13 @@ test('real world example', () => {
   let actions = [
     {action: {type: '@@init'}, value: 0},
     {action: actionCreators.set(2), value: 2},
+    {action: actionCreators.begin('start-at-1'), value: 2},
     {action: actionCreators.set(1, 'start-at-1'), value: 1},
     {action: actionCreators.incrementIfEven(), value: 1},
-    {action: actionCreators.increment('inc'), value: 2},
-    {action: actionCreators.commit('inc'), value: 2},
+    {action: actionCreators.increment('start-at-1'), value: 2},
+    {action: actionCreators.begin('inc'), value: 2},
+    {action: actionCreators.increment('inc'), value: 3},
+    {action: actionCreators.commit('inc'), value: 3},
     {action: actionCreators.revert('start-at-1'), value: 4},
   ];
   let state;

--- a/test/index.js
+++ b/test/index.js
@@ -204,19 +204,19 @@ test('real world example', () => {
       return {
         type: 'SET',
         value: value,
-        optimist: transactionID ? {type: optimist.BEGIN, id: transactionID} : undefined
+        optimist: transactionID ? {id: transactionID} : undefined
       };
     },
     increment(transactionID) {
       return {
         type: 'INCREMENT',
-        optimist: transactionID ? {type: optimist.BEGIN, id: transactionID} : undefined
+        optimist: transactionID ? {id: transactionID} : undefined
       };
     },
     incrementIfEven(transactionID) {
       return {
         type: 'INCREMENT_IF_EVEN',
-        optimist: transactionID ? {type: optimist.BEGIN, id: transactionID} : undefined
+        optimist: transactionID ? {id: transactionID} : undefined
       };
     },
     begin(transactionID) {


### PR DESCRIPTION
Revert skips the first action with the specified ID, but it mistakenly replays all subsequent actions with ID. Need to filter those out when creating newOptimist.

I'll let you handle your src - my JS isn't as sweet.
