### PR TITLE
Simplified commit and revert reducers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ function optimist(fn) {
       }
     });
     if (!committed) {
-      console.error('Cannot commit transaction with id "my-transaction" because it does not exist');
+      console.error('Cannot commit transaction with id "' + action.optimist.id + '" because it does not exist');
     }
     optimist = newOptimist;
     return baseReducer(optimist, innerState, action);
@@ -85,7 +85,7 @@ function optimist(fn) {
       }
     });
     if (!gotInitialState) {
-      console.error('Cannot revert transaction with id "my-transaction" because it does not exist');
+      console.error('Cannot revert transaction with id "' + action.optimist.id + '" because it does not exist');
     }
     optimist = newOptimist;
     return baseReducer(optimist, currentState, action);

--- a/src/index.js
+++ b/src/index.js
@@ -22,27 +22,19 @@ function optimist(fn) {
     let {optimist, innerState} = separateState(state);
     var newOptimist = [], started = false, committed = false;
     optimist.forEach(function (entry) {
-      if (started) {
-        if (
-          entry.beforeState &&
-          matchesTransaction(entry.action, action.optimist.id)
-        ) {
+      if (matchesTransaction(entry.action, action.optimist.id)) {
+        if (entry.beforeState) {
           committed = true;
-          newOptimist.push({action: entry.action});
-        } else {
-          newOptimist.push(entry);
+          entry = {action: entry.action} // Strip beforeState - we're never going to need to revert to it.
         }
-      } else if (
-        entry.beforeState &&
-        !matchesTransaction(entry.action, action.optimist.id)
-      ) {
-        started = true;
+      }
+      else {
+        if (entry.beforeState) {
+          started = true; // We're in an open transaction, start recording all entries
+        }
+      }
+      if (started) {
         newOptimist.push(entry);
-      } else if (
-        entry.beforeState &&
-        matchesTransaction(entry.action, action.optimist.id)
-      ) {
-        committed = true;
       }
     });
     if (!committed) {

--- a/src/index.js
+++ b/src/index.js
@@ -44,39 +44,34 @@ function optimist(fn) {
     return baseReducer(optimist, innerState, action);
   }
   function revertReducer(state, action) {
-    let {optimist, innerState} = separateState(state);
-    var newOptimist = [], started = false, gotInitialState = false, currentState = innerState;
+    let {optimist, ...ignore} = separateState(state);
+    var newOptimist = [], started = false, currentState = undefined;
     optimist.forEach(function (entry) {
-      if (
-        entry.beforeState &&
-        matchesTransaction(entry.action, action.optimist.id)
-      ) {
-        currentState = entry.beforeState;
-        gotInitialState = true;
-      }
-      if (!matchesTransaction(entry.action, action.optimist.id)) {
-        if (
-          entry.beforeState
-        ) {
-          started = true;
+      if (matchesTransaction(entry.action, action.optimist.id)) {
+        if (entry.beforeState) {
+          currentState = entry.beforeState;
         }
-        if (started) {
-          if (gotInitialState && entry.beforeState) {
-            newOptimist.push({
+      }
+      else {
+        if (entry.beforeState) {
+          started = true;
+          if (currentState) {
+            entry = {
               beforeState: currentState,
               action: entry.action
-            });
-          } else {
-            newOptimist.push(entry);
+            };
           }
         }
-        if (gotInitialState) {
+        if (started) {
+          newOptimist.push(entry);
+        }
+        if (currentState) {
           currentState = fn(currentState, entry.action);
-          validateState(innerState, action);
+          validateState(currentState, action);
         }
       }
     });
-    if (!gotInitialState) {
+    if (currentState==null) {
       console.error('Cannot revert transaction with id "' + action.optimist.id + '" because it does not exist');
     }
     optimist = newOptimist;


### PR DESCRIPTION
I was trying to understand the new logic and couldn't keep the conditions straight in my head. I simplified them by making a single decision about whether we're dealing with an entry from the transaction of interest. Also, there's only one place where entries get pushed into the newOptimist.
