### PR TITLE
Fix import location for redux-optimist in README code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ have to use `Redux.combineReducers`.
 #### `middleware/api.js`
 
 ```js
-import {BEGIN, COMMIT, REVERT} from 'optimist';
+import {BEGIN, COMMIT, REVERT} from 'redux-optimist';
 import request from 'then-request';
 
 let nextTransactionID = 0;


### PR DESCRIPTION
Embarrassing, but I actually tried to import from 'optimist' after reviewing
the README which caused me a little confusion.
