### PR TITLE
Added .babelrc to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@ logs
 npm-debug.log
 node_modules
 /src
+.babelrc


### PR DESCRIPTION
The `.babelrc` was causing `react-native` builds to fail. Added to npmignore to prevent this clash.
