### PR TITLE
Remove .babelrc from the published package (for using with React Native)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
     "type": "git",
     "url": "https://github.com/ForbesLindesay/redux-optimist.git"
   },
+  "files": [
+    "index.js",
+    "lib"
+  ],
   "author": "ForbesLindesay",
   "license": "MIT"
 }


### PR DESCRIPTION
Installed from npm, this package doesn't work with React Native, because although the released code is transpiled, `.babelrc` is also published to npm.

Fixed by adding the `files` property in package.json to prevent .babelrc from being published.

See:
https://github.com/facebook/react-native/issues/4062