### PR TITLE
Remove deprecated babel option

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "presets": ["import-export"],
+  "presets": ["import-export", "es2015"],
   "plugins": ["transform-object-rest-spread"]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "optional": ["es7.objectRestSpread"]
+  "presets": ["import-export"],
+  "plugins": ["transform-object-rest-spread"]
 }

--- a/package.json
+++ b/package.json
@@ -3,12 +3,11 @@
   "version": "0.0.2",
   "description": "Optimistically apply actions that can be later commited or reverted.",
   "keywords": [],
-  "dependencies": {
+  "dependencies": {},
+  "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "babel-preset-import-export": "^1.0.2"
-  },
-  "devDependencies": {
+    "babel-preset-import-export": "^1.0.2",
     "babel-istanbul": "^0.3.20",
     "chalk": "^1.1.1",
     "diff": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "0.0.2",
   "description": "Optimistically apply actions that can be later commited or reverted.",
   "keywords": [],
-  "dependencies": {},
-  "devDependencies": {
+  "dependencies": {
     "babel-cli": "^6.26.0",
     "babel-istanbul": "^0.3.20",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
   "dependencies": {},
   "devDependencies": {
     "babel-cli": "^6.26.0",
-    "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "babel-preset-import-export": "^1.0.2",
     "babel-istanbul": "^0.3.20",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-import-export": "^1.0.2",
     "chalk": "^1.1.1",
     "diff": "^2.1.2",
     "testit": "^2.0.2"

--- a/package.json
+++ b/package.json
@@ -3,9 +3,12 @@
   "version": "0.0.2",
   "description": "Optimistically apply actions that can be later commited or reverted.",
   "keywords": [],
-  "dependencies": {},
+  "dependencies": {
+    "babel-cli": "^6.26.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "babel-preset-import-export": "^1.0.2"
+  },
   "devDependencies": {
-    "babel": "^5.8.23",
     "babel-istanbul": "^0.3.20",
     "chalk": "^1.1.1",
     "diff": "^2.1.2",


### PR DESCRIPTION
This PR removes the `optional` key from `.babelrc`, which was deprecated and in newer versions this is breaking babel:
```
ReferenceError: [BABEL] **/myproject/node_modules/redux-optimist/index.js: Using removed Babel 5 option: **/myproject/node_modules/redux-optimist/.babelrc.optional - Put the specific transforms you want in the `plugins` option
```

Also, this updates `babel` (for `babel-cli`) and also add presets and plugins to transpile spread operators and import/export syntax.
