### PR TITLE
Preserve state reference if unchanged and not in transaction

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -109,17 +109,15 @@ function optimist(fn) {
           return revertReducer(state, action);
       }
     }
-    if (!state || !state.optimist || state.optimist.length) {
-      let separated = separateState(state);
-      return baseReducer(separated.optimist, separated.innerState, action);      
+
+    let {optimist, innerState} = separateState(state);
+    if (state) {
+      let nextState = fn(innerState, action);
+      if (nextState === innerState && !optimist.length) {
+        return state;
+      }
     }
-    let nextState = fn(state, action);
-    if (nextState === state) {
-      return state;
-    }
-    validateState(nextState, action);
-    nextState.optimist = state.optimist;
-    return nextState;
+    return baseReducer(optimist, innerState, action);
   };
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -111,11 +111,13 @@ function optimist(fn) {
     }
 
     let {optimist, innerState} = separateState(state);
-    if (state) {
+    if (state && !optimist.length) {
       let nextState = fn(innerState, action);
-      if (nextState === innerState && !optimist.length) {
+      if (nextState === innerState) {
         return state;
       }
+      validateState(nextState, action);
+      return {optimist, ...nextState};
     }
     return baseReducer(optimist, innerState, action);
   };

--- a/src/index.js
+++ b/src/index.js
@@ -109,8 +109,17 @@ function optimist(fn) {
           return revertReducer(state, action);
       }
     }
-    let separated = separateState(state);
-    return baseReducer(separated.optimist, separated.innerState, action);
+    if (!state || !state.optimist || state.optimist.length) {
+      let separated = separateState(state);
+      return baseReducer(separated.optimist, separated.innerState, action);      
+    }
+    let nextState = fn(state, action);
+    if (nextState === state) {
+      return state;
+    }
+    validateState(nextState, action);
+    nextState.optimist = state.optimist;
+    return nextState;
   };
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -398,12 +398,25 @@ test('real world example 2', () => {
   assert.deepEqual(state, {optimist: [], value: 4});
 });
 
+test('calls original reducer max of one time per action', () => {
+  let calls = 0;
+  function originalReducer(state) {
+    calls++;
+    return {};
+  }
+  let reducer = optimist(originalReducer);
+  let state;
+  state = reducer(state, {type: '@@init'});
+  state = reducer(state, {type: 'foo'});
+  assert.equal(calls, 2);
+});
+
 test('unhandled action state reference', () => {
-  let originalReducer = ( state = {} ) => state;
+  let originalReducer = (state = {}) => state;
   let reducer = optimist(originalReducer);
   let initState = reducer(undefined, {type: '@@init'});
-  let originalState = reducer(initState, {type: 'UNHANDLED_ACTION'});
-  let nextState = reducer(originalState, {type: 'UNHANDLED_ACTION'});
+  let originalState = reducer(initState, {type: 'foo'});
+  let nextState = reducer(originalState, {type: 'foo'});
   assert.strictEqual(originalState, nextState);
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -387,6 +387,15 @@ test('real world example 2', () => {
   assert.deepEqual(state, {optimist: [], value: 4});
 });
 
+test('unhandled action state reference', () => {
+  let state = {};
+  let originalReducer = () => state;
+  let reducer = optimist(originalReducer);
+  let initState = reducer(undefined, {type: '@@init'});
+  let originalState = reducer(initState, {type: 'UNHANDLED_ACTION'});
+  let nextState = reducer(originalState, {type: 'UNHANDLED_ACTION'});
+  assert.strictEqual(originalState, nextState);
+});
 
 function basic(name, {reducer, before, action, after}) {
   test(name, () => {

--- a/test/index.js
+++ b/test/index.js
@@ -264,6 +264,17 @@ basic('commit other transaction', {
   }
 });
 
+test('omits optimist from original reducer', () => {
+  function originalReducer(state = {value: 0}, action) {
+    assert(state.value === 0);
+    assert(!state.hasOwnProperty('optimist'));
+    return state;
+  }
+  let reducer = optimist(originalReducer);
+  let state;
+  state = reducer(state, {type: 'foo'});
+  state = reducer(state, {type: 'foo'});
+});
 
 test('real world example', () => {
   function originalReducer(state = {value: 0}, action) {

--- a/test/index.js
+++ b/test/index.js
@@ -388,8 +388,7 @@ test('real world example 2', () => {
 });
 
 test('unhandled action state reference', () => {
-  let state = {};
-  let originalReducer = () => state;
+  let originalReducer = ( state = {} ) => state;
   let reducer = optimist(originalReducer);
   let initState = reducer(undefined, {type: '@@init'});
   let originalState = reducer(initState, {type: 'UNHANDLED_ACTION'});


### PR DESCRIPTION
Fixes #22 

This pull request seeks to resolve an issue where `redux-optimist` returns a new state reference on every dispatch, regardless of whether the original reducer has in-fact returned a new value.

The approach is perhaps not quite as elegant as I'd hope, since it moves logic from what might otherwise be considered part of the `baseReducer` into the return function of the top-level `optimist`. After banging my head at several attempts trying to incorporate into `baseReducer` while also accommodating `commitReducer` and `revertReducer`, this is what I landed on.

The idea is that if we're not in the middle of a transaction and the original reducer produces a strictly equal value to the previous state, we shouldn't bother to separate state, which is not only potentially costly (in iterating over the spread assignment of `innerState` from `separateState`) but is the root cause for the new reference being returned (destructuring this way will guarantee `innerState` is always a new value).

I've included a test case which fails in master, and granted you access to edit my branch, in case you'd like to hack away at a refactor while achieving the same intent.